### PR TITLE
Add KodeKloud free lab resource to Kubernetes Deployments topic

### DIFF
--- a/src/data/roadmaps/kubernetes/content/deploying-your-first-application@zrbSJa3k7a3TE0aYbWi9c.md
+++ b/src/data/roadmaps/kubernetes/content/deploying-your-first-application@zrbSJa3k7a3TE0aYbWi9c.md
@@ -9,3 +9,4 @@ Visit the following resources to learn more:
 - [@article@Kubernetes 101: Deploy Your First Application with MicroK8s](https://thenewstack.io/kubernetes-101-deploy-your-first-application-with-microk8s/)
 - [@video@Kubernetes Tutorial | Your First Kubernetes Application](https://www.youtube.com/watch?v=Vj6EFnav5Mg)
 - [@video@Kubernetes 101: Deploying Your First Application](https://www.youtube.com/watch?v=XltFOyGanYE)
+- [@course@Kubernetes Deployment Hands-on Lab](https://kodekloud.com/studio/labs/kubernetes/deployments-stable)


### PR DESCRIPTION
This update adds KodeKloud’s free hands-on labs under the Kubernetes Deployments topic in the roadmap.

While the roadmap uses the @course tag for structure, this isn’t an actual course - it’s meant to guide learners through practical, hands-on Kubernetes App Deployment experience using KodeKloud’s free lab environment.

These labs help users practice real deployment scenarios and gain practical Kubernetes skills, making the roadmap more interactive and experience-driven.